### PR TITLE
Add vscode settings for prettier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
Adds a `.vscode/settings.json` file which just sets the Prettier extension as the default formatter for this project. This doesn't set up anything too opinionated like formatting on save, but since we're all using prettier I figure recommending the extension for people opening the repo for the first time makes sense.

Alternately, if we don't want this committed, we can just .gitignore this file.